### PR TITLE
Update power profile for Pie

### DIFF
--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -17,7 +17,7 @@
         <value>2</value>
         <value>1</value>
     </array>
-    <array name="cpu.speeds">
+    <array name="cpu.core_speeds.cluster0">
         <value>400000</value>
         <value>533333</value>
         <value>800000</value>
@@ -26,8 +26,9 @@
         <value>1152000</value>
         <value>1209600</value>
     </array>
-    <item name="cpu.idle">2.8</item>
-    <array name="cpu.active">
+    <item name="cpu.clusters.cores">4</item>
+    <item name="cpu.suspend">2.8</item>
+    <array name="cpu.core_power.cluster0">
         <value>51.2</value>
         <value>60.4</value>
         <value>72.9</value>


### PR DESCRIPTION
* Match the changes made in LineageOS/android_frameworks_base@3d422c3

* Since Pie, AOSP is forcing us to define speeds and power values per CPU cluster.
  For single cluster chipsets like MSM8916, define cluster0 with only 4 cores
  to retain the existing behaviour.

Thanks @ghostrider-reborn